### PR TITLE
Fix PHP 8+ Warning: Trying to access array offset on false in do...while loops

### DIFF
--- a/src/voku/helper/Hooks.php
+++ b/src/voku/helper/Hooks.php
@@ -314,7 +314,7 @@ class Hooks
 
     do {
       foreach ((array)\current($this->filters[$tag]) as $the_) {
-        if (null !== $the_['function']) {
+        if (\is_array($the_) && null !== $the_['function']) {
 
           if (null !== $the_['include_path']) {
             /** @noinspection PhpIncludeInspection */
@@ -371,7 +371,7 @@ class Hooks
 
     do {
       foreach ((array)\current($this->filters[$tag]) as $the_) {
-        if (null !== $the_['function']) {
+        if (\is_array($the_) && null !== $the_['function']) {
 
           if (null !== $the_['include_path']) {
             /** @noinspection PhpIncludeInspection */
@@ -548,7 +548,7 @@ class Hooks
 
     do {
       foreach ((array)\current($this->filters[$tag]) as $the_) {
-        if (null !== $the_['function']) {
+        if (\is_array($the_) && null !== $the_['function']) {
 
           if (null !== $the_['include_path']) {
             /** @noinspection PhpIncludeInspection */
@@ -614,7 +614,7 @@ class Hooks
 
     do {
       foreach ((array)\current($this->filters[$tag]) as $the_) {
-        if (null !== $the_['function']) {
+        if (\is_array($the_) && null !== $the_['function']) {
 
           if (null !== $the_['include_path']) {
             /** @noinspection PhpIncludeInspection */
@@ -708,7 +708,7 @@ class Hooks
 
     do {
       foreach ((array)\current($this->filters['all']) as $the_) {
-        if (null !== $the_['function']) {
+        if (\is_array($the_) && null !== $the_['function']) {
 
           if (null !== $the_['include_path']) {
             /** @noinspection PhpIncludeInspection */


### PR DESCRIPTION
In PHP 8+, when current() returns false at the end of an array pointer, casting it with (array)false yields [0 => false]. The foreach loop then assigns $the_ = false, and accessing $the_['function'] triggers:

Warning: Trying to access array offset on false

Fix: Add is_array($the_) check before accessing array keys in all five do...while loops:
- apply_filters()
- apply_filters_ref_array()
- do_action()
- do_action_ref_array()
- _call_all_hook()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/php-hooks/17)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hook processing to prevent notices and errors when encountering invalid hook data, improving overall system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->